### PR TITLE
Scan fixed shader texture range to dump higher-slot textures

### DIFF
--- a/src/main/java/ru/promej/modeldumper/exporter/MultiBufferObjConsumer.java
+++ b/src/main/java/ru/promej/modeldumper/exporter/MultiBufferObjConsumer.java
@@ -33,12 +33,12 @@ public class MultiBufferObjConsumer implements VertexConsumerProvider {
 
                 lastConsumer.writeData(new File(outputFolder, id++ + ".obj"));
                 lastType.startDrawing();
-                int textureId = 0;
-                int shaderId = 0;
-                do {
-                    textureId = RenderSystem.getShaderTexture(shaderId);
-                    shaderId++;
-                    if(textureId == 0 || dumpedTextureIds.contains(textureId)) {
+                for (int shaderId = 0; shaderId < 16; shaderId++) {
+                    int textureId = RenderSystem.getShaderTexture(shaderId);
+                    if (textureId == 0) {
+                        continue;
+                    }
+                    if(dumpedTextureIds.contains(textureId)) {
                         break;
                     }
                     dumpedTextureIds.add(textureId);
@@ -55,8 +55,6 @@ public class MultiBufferObjConsumer implements VertexConsumerProvider {
                         e.printStackTrace();
                     }
                 }
-
-                while(textureId != 0);
 
             } catch (IOException e) {
                 e.printStackTrace();


### PR DESCRIPTION
## Summary
- Iterate over shader texture slots 0-15 instead of looping until a zero is encountered
- Skip empty slots and continue scanning to capture textures bound to higher slots

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68b2d6ee6c1c8326b7fe1e5db9003897