### PR TITLE
Handle alpha and clamp texture sampling in exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Adds `dump` hotkeys(not bound by default!) to the game that dumps the currently rendered models to a file.
 The output file is a `.obj` file that can be opened in any 3D modeling software and the required textures are also dumped. The model is uv mapped, so the textures should be applied correctly. Important: The model is not rigged, it is just a static model in the current pose of the game.
+In addition, a combined `.glb` model is generated with textures configured for pixel art (NEAREST filtering and clamped edges) and full alpha channel support.
 Currently works with:
 
 - Players

--- a/src/main/java/ru/promej/modeldumper/exporter/GlbExporter.java
+++ b/src/main/java/ru/promej/modeldumper/exporter/GlbExporter.java
@@ -38,8 +38,11 @@ public class GlbExporter {
 
             // one sampler with NEAREST filtering for pixel art
             JsonObject sampler = new JsonObject();
-            sampler.addProperty("magFilter", 9728);
-            sampler.addProperty("minFilter", 9728);
+            sampler.addProperty("magFilter", 9728); // GL_NEAREST
+            sampler.addProperty("minFilter", 9728); // GL_NEAREST
+            // avoid texture bleeding by clamping
+            sampler.addProperty("wrapS", 33071); // GL_CLAMP_TO_EDGE
+            sampler.addProperty("wrapT", 33071); // GL_CLAMP_TO_EDGE
             samplers.add(sampler);
             int samplerIndex = 0;
 

--- a/src/main/java/ru/promej/modeldumper/exporter/ObjConsumer.java
+++ b/src/main/java/ru/promej/modeldumper/exporter/ObjConsumer.java
@@ -102,7 +102,9 @@ public class ObjConsumer implements VertexConsumer {
                 for(String tex : textures) {
                     String material = tex.substring(0, tex.lastIndexOf('.'));
                     out.write("newmtl " + material + "\n");
-                    out.write("map_Kd " + tex + "\n\n");
+                    out.write("map_Kd " + tex + "\n");
+                    // Explicit alpha map so OBJ loaders respect transparency
+                    out.write("map_d " + tex + "\n\n");
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Clamp GLB texture sampler to avoid bleeding and stick with NEAREST filtering
- Preserve transparency in OBJ materials via `map_d`
- Document GLB export with pixel-art texture settings and alpha support

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68b2df4563b48326965f5135208e7473